### PR TITLE
0.5.1 dev

### DIFF
--- a/Baseline.sh
+++ b/Baseline.sh
@@ -6,7 +6,7 @@ set -x
 #   @BigMacAdmin on the MacAdmins Slack
 #   trevor@secondsonconsulting.com
 
-scriptVersion="v.0.5.0"
+scriptVersion="v.0.5.1"
 
 ########################################################################################################
 ########################################################################################################
@@ -246,7 +246,7 @@ function install_dialog()
                 /usr/sbin/installer -pkg "$BaselinePackages/SwiftDialog.pkg" -target /  > /dev/null 2>&1
         # If Installomator is already here use that
         elif [ -e "$installomatorPath" ]; then
-            "$installomatorPath" swiftdialog INSTALL=force NOTIFY=silent > /dev/null 2>&1
+            "$installomatorPath" swiftdialog INSTALL=force NOTIFY=silent BLOCKING_PROCESS_ACTION=ignore > /dev/null 2>&1
             dialogInstallAttempts=$((dialogInstallAttempts+1))
         else
             # Get the URL of the latest PKG From the Dialog GitHub repo

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 set -x
-dryRun=1
+#dryRun=1
 
 #   Written by Trevor Sysock of Second Son Consulting
 #   @BigMacAdmin on the MacAdmins Slack
@@ -227,15 +227,6 @@ function no_sleeping()
 
 # execute a dialog command
 function dialog_command(){
-#    debug_message "DIALOGCMD: $@"
-    /bin/echo "$@"  >> $dialogCommandFile
-    sleep .1
-}
-
-# execute a dialog command
-function dialog_list_command()
-{
-    #    debug_message "DIALOGCMD: $@"
     /bin/echo "$@"  >> $dialogCommandFile
     sleep .1
 }
@@ -256,6 +247,7 @@ function install_dialog()
         # If Installomator is already here use that
         elif [ -e "$installomatorPath" ]; then
             "$installomatorPath" swiftdialog INSTALL=force NOTIFY=silent > /dev/null 2>&1
+            dialogInstallAttempts=$((dialogInstallAttempts+1))
         else
             # Get the URL of the latest PKG From the Dialog GitHub repo
             # Expected Team ID of the downloaded PKG
@@ -405,17 +397,17 @@ function process_installomator_labels()
         #Get the display name of the label we're installing. We need this to update the dialog list
         currentDisplayName=$($pBuddy -c "Print :Installomator:${currentIndex}:DisplayName" "$BaselineConfig")
         #Update the dialog window so that this item shows as "pending"
-        dialog_list_command "listitem: $currentDisplayName: wait"
+        dialog_command "listitem: $currentDisplayName: wait"
         #Call installomator with our desired options. Default options first, so that they can be overriden by "currentArguments"
         $installomatorPath $currentLabel ${defaultInstallomatorOptions[@]} $currentArguments > /dev/null 2>&1
         installomatorExitCode=$?
         if [ $installomatorExitCode != 0 ]; then
             report_message "Installomator failed to install: $currentLabel - Exit Code: $installomatorExitCode"
-            dialog_list_command "listitem: $currentDisplayName: fail"
+            dialog_command "listitem: $currentDisplayName: fail"
             failList+=("$currentDisplayName")
         else
             report_message "Installomator successfully installed: $currentLabel"
-            dialog_list_command "listitem: $currentDisplayName: success"
+            dialog_command "listitem: $currentDisplayName: success"
             successList+=("$currentDisplayName")
        fi
         currentIndex=$((currentIndex+1))
@@ -499,7 +491,7 @@ function process_scripts()
             # Iterate the index up one
             currentIndex=$((currentIndex+1))
             # Report the fail
-            dialog_list_command "listitem: $currentDisplayName: fail"
+            dialog_command "listitem: $currentDisplayName: fail"
             failList+=("$currentDisplayName")
             # Bail this pass through the while loop and continue processing next item
             continue
@@ -517,7 +509,7 @@ function process_scripts()
                 # Iterate the index up one
                 currentIndex=$((currentIndex+1))
                 # Report the fail
-                dialog_list_command "listitem: $currentDisplayName: fail"
+                dialog_command "listitem: $currentDisplayName: fail"
                 failList+=("$currentDisplayName")
                 # Bail this pass through the while loop and continue processing next item
                 continue
@@ -540,18 +532,18 @@ function process_scripts()
         fi
 
         #Update the dialog window so that this item shows as "pending"
-        dialog_list_command "listitem: $currentDisplayName: wait"
+        dialog_command "listitem: $currentDisplayName: wait"
 
         #Call our script with our desired options. Default options first, so that they can be overriden by "currentArguments"
         "$currentScript" ${currentArgumentArray[@]} >> "$ScriptOutputLog" 2>&1
         scriptExitCode=$?
         if [ $scriptExitCode != 0 ]; then
             report_message "Script failed to complete: $currentScript - Exit Code: $scriptExitCode"
-            dialog_list_command "listitem: $currentDisplayName: fail"
+            dialog_command "listitem: $currentDisplayName: fail"
             failList+=("$currentDisplayName")
         else
             report_message "Script completed successfully: $currentScript"
-            dialog_list_command "listitem: $currentDisplayName: success"
+            dialog_command "listitem: $currentDisplayName: success"
             successList+=("$currentDisplayName")
        fi
 
@@ -625,7 +617,7 @@ function process_pkgs()
                 # Iterate the index up one
                 currentIndex=$((currentIndex+1))
                 # Report the fail
-                dialog_list_command "listitem: $currentDisplayName: fail"
+                dialog_command "listitem: $currentDisplayName: fail"
                 # Bail this pass through the while loop and continue processing next item
                 continue
             else
@@ -644,7 +636,7 @@ function process_pkgs()
             currentPKG="$BaselinePackages/$currentPKGPath"
         else
             report_message "Package not found $currentPKGPath"
-            dialog_list_command "listitem: $currentDisplayName: fail"
+            dialog_command "listitem: $currentDisplayName: fail"
             failList+=("$currentDisplayName")
             currentIndex=$((currentIndex+1))
             continue
@@ -681,7 +673,7 @@ function process_pkgs()
             expectedMD5=""
         fi
         #Update the dialog window so that this item shows as "pending"
-        dialog_list_command "listitem: $currentDisplayName: wait"
+        dialog_command "listitem: $currentDisplayName: wait"
         
         ## Package validation happens here
         # Check TeamID, if a value has been provided
@@ -691,12 +683,12 @@ function process_pkgs()
             # Check if actual does not match expected
             if [ "$expectedTeamID" != "$actualTeamID" ]; then
                 report_message "TeamID validation of PKG failed: $currentPKG - Expected: $expectedTeamID Actual: $actualTeamID"
-                dialog_list_command "listitem: $currentDisplayName: fail"
+                dialog_command "listitem: $currentDisplayName: fail"
                 failList+=("$currentDisplayName")
                 # Iterate the index up one
                 currentIndex=$((currentIndex+1))
                 # Report the fail
-                dialog_list_command "listitem: $currentDisplayName: fail"
+                dialog_command "listitem: $currentDisplayName: fail"
                 # Bail this pass through the while loop and continue processing next item
                 continue
             else
@@ -711,12 +703,12 @@ function process_pkgs()
             # Check if actual does not match expected
             if [ "$expectedMD5" != "$actualMD5" ]; then
                 report_message "MD5 validation of PKG failed: $currentPKG - Expected: $expectedMD5 Actual: $actualMD5"
-                dialog_list_command "listitem: $currentDisplayName: fail"
+                dialog_command "listitem: $currentDisplayName: fail"
                 failList+=("$currentDisplayName")
                 # Iterate the index up one
                 currentIndex=$((currentIndex+1))
                 # Report the fail
-                dialog_list_command "listitem: $currentDisplayName: fail"
+                dialog_command "listitem: $currentDisplayName: fail"
                 # Bail this pass through the while loop and continue processing next item
                 continue
             else
@@ -731,11 +723,11 @@ function process_pkgs()
         # Verify the install completed successfully
         if [ $pkgExitCode != 0 ]; then
             report_message "Package failed to complete: $currentPKG - Exit Code: $pkgExitCode"
-            dialog_list_command "listitem: $currentDisplayName: fail"
+            dialog_command "listitem: $currentDisplayName: fail"
             failList+=("$currentDisplayName")
         else
             report_message "Package completed successfully: $currentPKG"
-            dialog_list_command "listitem: $currentDisplayName: success"
+            dialog_command "listitem: $currentDisplayName: success"
             successList+=("$currentDisplayName")
         fi
         debug_message "Output of the install package command: $pkgInstallerOutput"
@@ -899,11 +891,11 @@ process_scripts Scripts
 
 #Check if we have a custom Dialog.app icon waiting to process. If yes, reinstall dialog
 if [ -e "/Library/Application Support/Dialog/Dialog.png" ]; then
-    dialog_list_command "listitem: add, title: Finishing up"
-    dialog_list_command "listitem: Finishing up: wait"
+    dialog_command "listitem: add, title: Finishing up"
+    dialog_command "listitem: Finishing up: wait"
     rm_if_exists "$dialogAppPath"
     install_dialog
-    dialog_list_command "listitem: Finishing up: success"
+    dialog_command "listitem: Finishing up: success"
 fi
 
 if [ "$dryRun" = 1 ]; then

--- a/ExampleInitialScripts/InitialScriptExample-1.sh
+++ b/ExampleInitialScripts/InitialScriptExample-1.sh
@@ -1,0 +1,109 @@
+#!/bin/zsh
+# Uncomment this for verbose debug
+#set -x 
+
+##########
+# This is an example script designed to show some of the features of Baseline.
+# Written by: Trevor Sysock of Second Son Consulting
+# @BigMacAdmin on Github and Slack
+#
+# In this example, we're making an InitialScript that will prompt the user to choose their 
+# department and then rename the computer and put a script in place to be processed by Baseline 
+# according to the user's response.
+#
+# This script assumes you have the following in place:
+# - A Baseline configuration file containing this script in the "InitialScripts" section and "DepartmentSetup.sh" in the "Scripts" section.
+# - One or more scripts named to match the abbreviation of the department the user chooses.
+#   - /usr/local/Baseline/Scripts/
+#        - Acct.sh
+#        - Sales.sh
+#        - Exec.sh
+#        - Art.sh
+#        - Tech.sh
+# - A "default" script in the Baseline Scripts directory name "DepartmentSetup.sh"
+#
+# When the user chooses a department, the script associated with that department is renamed "DepartmentSetup.sh", and will be processed by Baseline.
+
+#############
+# Functions #
+#############
+
+# Verify we are running as root
+if [[ $(id -u) -ne 0 ]]; then
+  echo "ERROR: This script must be run as root **EXITING**"
+  exit 1
+fi
+
+#############
+# Variables #
+#############
+
+# Company name or abbreviation used for naming the computer
+companyName="Acme"
+
+# Path to SwiftDialog
+dialogPath='/usr/local/bin/dialog'
+
+# Path to Baseline Scripts directory
+BaselineScripts="/usr/local/Baseline/Scripts"
+
+# Get the shortname of the current user
+currentUser=$( echo "show State:/Users/ConsoleUser" | scutil | awk '/Name :/ { print $3 }' )
+# Get the UID of the current user
+currentUserUID=$(/usr/bin/id -u "$currentUser")
+# Get the Display Name of the current user
+currentUserDisplayName=$(id -F "$currentUser")
+# Get the First Name of the current user
+firstName=$(/usr/bin/id -F "$currentUser"| cut -d ' ' -f 1)
+
+# Setup your welcome experience
+welcomeTitle="Help Us Name Your Mac."
+welcomeBody="Hi $currentUserDisplayName, lets get your computer setup.\n\n To start, please choose your department."
+departmentChoices="Art,Sales,Accounting,Executive,Technician"
+
+######################
+# Script Starts Here #
+######################
+
+# Call the dialog command and put the results in a variable, so we can check against them afterwards
+departmentSelection=$("$dialogPath" \
+--title "$welcomeTitle" \
+--message "$welcomeBody" \
+--selecttitle "Department" \
+--ontop \
+--blurscreen \
+--position top \
+--selectvalues "$departmentChoices")
+
+# Set the Department Abbreviation based on user input
+case $departmentSelection in
+
+    *'"Department" : "Accounting"'*)
+        departmentAbbr="Acct"
+        ;;
+    *'"Department" : "Sales"'*)
+        departmentAbbr="Sales"
+        ;;
+    *'"Department" : "Executive"'*)
+        departmentAbbr="Exec"
+        ;;
+    *'"Department" : "Art"'*)
+        departmentAbbr="Art"
+        ;;
+    *'"Department" : "Technician"'*)
+        departmentAbbr="Tech"
+        ;;
+esac
+
+# Set the device name variable
+finalComputerName="$companyName"-"$departmentAbbr"-"$firstName"
+
+# Name the computer 3 ways
+scutil --set ComputerName $finalComputerName
+scutil --set HostName "$finalComputerName".shared
+scutil --set LocalHostName $finalComputerName
+
+# Check if there is a department script configured. If there is, rename it so that Baseline processes it.
+if [ -e "$BaselineScripts"/"$departmentAbbr".sh ]; then
+    mv "$BaselineScripts"/"$departmentAbbr".sh "$BaselineScripts"/DepartmentSetup.sh
+fi

--- a/PatchNotes_v0.5.1.md
+++ b/PatchNotes_v0.5.1.md
@@ -5,3 +5,4 @@
     - Initiated immediately upon a confirmed end user login, and prior to the main Dialog list.
     - There is no SwiftDialog window open while Initial Scripts are being processed. This means admins are welcome to create their own custom SwiftDialog experience with branding and messaging as you see fit.
     - It is recommended that Initial Scripts call a dialog window with the `--blurscreen` and `--ontop` options to match the defaults used in the main Baseline script.
+- Fixed a logic loop where Baseline would never exit if SwiftDialog wasn't installed successfully with Installomator.

--- a/PatchNotes_v0.5.1.md
+++ b/PatchNotes_v0.5.1.md
@@ -1,0 +1,7 @@
+## Baseline v0.5.1
+- Include the package `/usr/local/Baseline/Packages/SwiftDialog.pkg` to install a bundled copy of SwiftDialog instead of downloading.
+- An additional class of Scripts can now be defined as `InitialScripts`. Scripts in this dictionary are:
+    - Processed by the same function as `Scripts` and thus have the same requirements and features.
+    - Initiated immediately upon a confirmed end user login, and prior to the main Dialog list.
+    - There is no SwiftDialog window open while Initial Scripts are being processed. This means admins are welcome to create their own custom SwiftDialog experience with branding and messaging as you see fit.
+    - It is recommended that Initial Scripts call a dialog window with the `--blurscreen` and `--ontop` options to match the defaults used in the main Baseline script.

--- a/ProfileManifest/com.secondsonconsulting.baseline.plist
+++ b/ProfileManifest/com.secondsonconsulting.baseline.plist
@@ -127,6 +127,66 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
+			<string>These are the first items processed by Baseline, immediately when a user logs in.</string>
+			<key>pfm_name</key>
+			<string>InitialScripts</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_description</key>
+							<string>The name you want to appear in the SwiftDialog menu as this script is run.</string>
+							<key>pfm_name</key>
+							<string>DisplayName</string>
+							<key>pfm_title</key>
+							<string>Display Name</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>A path to the script you want to run. Can be a local file path or a URL.</string>
+							<key>pfm_name</key>
+							<string>ScriptPath</string>
+							<key>pfm_title</key>
+							<string>Script Path</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>The expected MD5 of the script being run.</string>
+							<key>pfm_name</key>
+							<string>MD5</string>
+							<key>pfm_title</key>
+							<string>MD5</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>Arguments you want to pass to the script when it is run.</string>
+							<key>pfm_name</key>
+							<string>Arguments</string>
+							<key>pfm_title</key>
+							<string>Arguments</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+					</array>
+					<key>pfm_type</key>
+					<string>dictionary</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>InitialScripts</string>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
 			<string>Populate with Installomator labels you wish Baseline to process when it runs.</string>
 			<key>pfm_name</key>
 			<string>Installomator</string>
@@ -304,6 +364,16 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Scripts</string>
 			<key>pfm_type</key>
 			<string>array</string>
+		</dict>
+		<dict>
+			<key>pfm_name</key>
+			<string>Restart</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+			<key>pfm_title</key>
+			<string>Restart</string>
+			<key>pfm_description</key>
+			<string>This setting controls whether Baseline forces a restart after completion. Default is true.</string>
 		</dict>
 	</array>
 	<key>pfm_targets</key>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Once the primary script is run, the following sequence occurs:
 1. Baseline then waits until an active end user is logged in on the device.
     1. This process does not have a timeout and will continue to wait until a user has logged into the device.
 1. When a valid user is identified `InitialScripts` are processed.
-    1. There is no SwiftDialog component to `InitialScripts`. This is where you can customize your welcome experience to suit your use case.
+    1. There is no SwiftDialog component to `InitialScripts`. This is where you can customize your welcome experience to suit your use case by writing your own SwiftDialog script and calling it here.
 1. Once `InitialScripts` are completed, a SwiftDialog progress list will show each additional item as it is processed.
 1. Installomator is used to process any labels defined in the configuration profile
 2. Any packages defined inthe configuration profile are run.
@@ -35,6 +35,7 @@ Once the primary script is run, the following sequence occurs:
 6. The entire directory `/usr/local/Baseline` is deleted.
 7. The user is presented with a simple message indicating whether everything went smoothly or if there were errors. This message has a timer.
 8. After the timer the device forcibly restarts via `shutdown -r now`
+    1. This restart can optionally be disabled
 
 ### Additional Info
 
@@ -116,7 +117,7 @@ Optional arguments for Packages:
 - `<MD5>` : Use this to define the expected md5 hash to ensure the integrity of your package.
 - `<Arguments>` : In the rare cases a .pkg has additional arguments you wish to pass through the `installer` command, you can do so using this key.
 
-## Define `Scripts`
+## Defining `Scripts`
 Required arguments for Scripts:
 - `<DisplayName>` : The human facing name of this item
 - `<ScriptPath>` : The path to the script to be installed. The path can be defined in three ways
@@ -143,11 +144,19 @@ Optional arguments for Scripts:
 </array>
 ```
 
-## Define `InitialScripts`
+## Defining `InitialScripts`
     - InitialScripts are processed by the same function as `Scripts` and thus have the same requirements and features.
     - InitialScripts are run immediately upon a confirmed end user login, and prior to the main Dialog list.
     - There is no SwiftDialog window open while Initial Scripts are being processed. This means admins are welcome to create their own custom SwiftDialog experience with branding and messaging as you see fit.
     - It is recommended that Initial Scripts call a dialog window with the `--blurscreen` and `--ontop` options to match the defaults used in the main Baseline script.
+
+## Configuring `Restart`
+    - By default, Baseline forces a restart on the device upon completion of all tasks. If you do not want this, you can add a boolean key ofr `Restart` and provide the value `false`
+    ```
+    <key>Restart</key>
+    <false\>
+    ```
+    If this key is provided, the device is not forced to restart and the final dialog window will not include a timer.
 
 ## Using iMazing Profile Editor
 Currently Baseline is not included in the iMazing Profile Editor default repository, when a full release is announced a pull request will be made to make this happen.

--- a/README.md
+++ b/README.md
@@ -24,19 +24,21 @@ Once the primary script is run, the following sequence occurs:
 1. The latest version of SwiftDialog is installed.
 1. Baseline then waits until an active end user is logged in on the device.
     1. This process does not have a timeout and will continue to wait until a user has logged into the device.
-1. When a valid user is identified a SwiftDialog progress list will show each item as its processed.
+1. When a valid user is identified `InitialScripts` are processed.
+    1. There is no SwiftDialog component to `InitialScripts`. This is where you can customize your welcome experience to suit your use case.
+1. Once `InitialScripts` are completed, a SwiftDialog progress list will show each additional item as it is processed.
 1. Installomator is used to process any labels defined in the configuration profile
 2. Any packages defined inthe configuration profile are run.
 3. Any scripts defined in the configuration profile are run.
 4. If a custom app icon has been configured for SwiftDialog, then it will be reinstalled in order to pickup this icon.
 5. Baseline deletes the LaunchDaemon, so that it is not loaded again after a restart.
 6. The entire directory `/usr/local/Baseline` is deleted.
-7. The user is presented with a simple message indicating whether everything went smoothly or if there were errors. This message has a timer (default 30 seconds for success, 5 minutes if any items had an error.)
+7. The user is presented with a simple message indicating whether everything went smoothly or if there were errors. This message has a timer.
 8. After the timer the device forcibly restarts via `shutdown -r now`
 
 ### Additional Info
 
-Baseline uses the `--blurscreen` SwiftDialog feature to prevent user access during the setup process. There is an optional "escape" key to close the Dialog windows using `CMD+]`. Using this escape key does not stop Baseline from running, it simply closes the Dialog window. 
+Baseline uses the `--blurscreen` SwiftDialog feature to prevent user access during the setup process. There is an optional "escape" key to close the Dialog windows using `CMD+]`. Using this escape key does not stop Baseline from running, it only closes the Dialog window. 
 
 ### How to Initiate it
 Baseline was designed to be run in any way you may need:
@@ -62,8 +64,13 @@ The full script output can be found at `/var/log/Baseline/DaemonOutput.log`
 
 # Configuration Profile
 Baseline performs actions based on a configuration profile delivered via MDM or manually installed. The top level keys in the profile are arrays with dictionaries defined beneath them.
+## Currently Supported Keys
+- `<InitialScripts>`
+- `<Installomator>`
+- `<Packages>`
+- `<Scripts>`
 
-## Defining Installomator Labels
+## Defining `Installomator` Labels
 
 By default, Baseline runs Installomator labels with the following arguments:
 `BLOCKING_PROCESS_ACTION=kill`
@@ -96,7 +103,7 @@ Example Installomator configurations:
 </array>
 ```
 
-## Defining Packages
+## Defining `Packages`
 Required arguments for Packages:
 - `<DisplayName>` : The human facing name of this item
 - `<PackagePath>` : The path to the package to be installed. The path can be defined in three ways
@@ -109,7 +116,7 @@ Optional arguments for Packages:
 - `<MD5>` : Use this to define the expected md5 hash to ensure the integrity of your package.
 - `<Arguments>` : In the rare cases a .pkg has additional arguments you wish to pass through the `installer` command, you can do so using this key.
 
-## Define Scripts
+## Define `Scripts`
 Required arguments for Scripts:
 - `<DisplayName>` : The human facing name of this item
 - `<ScriptPath>` : The path to the script to be installed. The path can be defined in three ways
@@ -135,6 +142,13 @@ Optional arguments for Scripts:
     </dict>
 </array>
 ```
+
+## Define `InitialScripts`
+    - InitialScripts are processed by the same function as `Scripts` and thus have the same requirements and features.
+    - InitialScripts are run immediately upon a confirmed end user login, and prior to the main Dialog list.
+    - There is no SwiftDialog window open while Initial Scripts are being processed. This means admins are welcome to create their own custom SwiftDialog experience with branding and messaging as you see fit.
+    - It is recommended that Initial Scripts call a dialog window with the `--blurscreen` and `--ontop` options to match the defaults used in the main Baseline script.
+
 ## Using iMazing Profile Editor
 Currently Baseline is not included in the iMazing Profile Editor default repository, when a full release is announced a pull request will be made to make this happen.
 For now, you can utilize iMazing by downloading the plist file in the "Profile Manifest" folder of this Github repo and then following the "Simple customization" instructions to get it in place on your workstation: https://imazing.com/guides/imazing-profile-editor-working-with-custom-preference-manifests


### PR DESCRIPTION
## Baseline v0.5.1
### New Features
- Include the package `/usr/local/Baseline/Packages/SwiftDialog.pkg` to install a bundled copy of SwiftDialog instead of downloading.
- An additional class of Scripts can now be defined as `InitialScripts`. Scripts in this dictionary are:
    - Processed by the same function as `Scripts` and thus have the same requirements and features.
    - Initiated immediately upon a confirmed end user login, and prior to the main Dialog list.
    - There is no SwiftDialog window open while Initial Scripts are being processed. This means admins are welcome to create their own custom SwiftDialog experience with branding and messaging as you see fit.
    - It is recommended that Initial Scripts call a dialog window with the `--blurscreen` and `--ontop` options to match the defaults used in the main Baseline script.
- New `Restart` configuration key.
    - Boolean value which when set to `false` will not force a restart at the completion of Baseline
    - Default is `true` and this key does not need to be included if you want to leave the default behavior
- Added `InitialScripts` and `Restart` to the ProfileManifest 
### Bug Fixes
- Fixed a logic loop where Baseline would never exit if SwiftDialog wasn't installed successfully with Installomator.
- General code cleanup