### PR TITLE
0.5.2 dev

### DIFF
--- a/Baseline.sh
+++ b/Baseline.sh
@@ -60,7 +60,6 @@ fi
 #Variables for our primary Dialog window
 dialogTitle="Your computer setup is underway"
 dialogMessage="Feel free to step away, this could take 30 minutes or more. \n\nYour computer will restart when it's ready for use."
-#^^^dialogIcon="/System/Library/CoreServices/Erase Assistant.app"
 dialogIcon="/System/Library/CoreServices/KeyboardSetupAssistant.app/Contents/Resources/AppIcon.icns"
 dialogAdditionalOptions=(
     --blurscreen

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -6,7 +6,7 @@ set -x
 #   @BigMacAdmin on the MacAdmins Slack
 #   trevor@secondsonconsulting.com
 
-scriptVersion="v.0.5.1"
+scriptVersion="v.0.5.2"
 
 ########################################################################################################
 ########################################################################################################
@@ -60,7 +60,8 @@ fi
 #Variables for our primary Dialog window
 dialogTitle="Your computer setup is underway"
 dialogMessage="Feel free to step away, this could take 30 minutes or more. \n\nYour computer will restart when it's ready for use."
-dialogIcon="/System/Library/CoreServices/Erase Assistant.app"
+#^^^dialogIcon="/System/Library/CoreServices/Erase Assistant.app"
+dialogIcon="/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/GenericFolderIcon.icns"
 dialogAdditionalOptions=(
     --blurscreen
     --width 900
@@ -876,20 +877,23 @@ scriptArguments=()
 pkgsToInstall=()
 pkgValidations=()
 
+##############################
+#   Process Initial Scripts  #
+##############################
+
+process_scripts InitialScripts
+
+###################
+#   Build Arrays  #
+###################
 # Build dialogList array by reading our configuration and looping through things
 
-#build_dialog_array InitialScripts
 build_dialog_array Installomator
 build_dialog_array Packages
 build_dialog_array Scripts
 
 build_dialog_list_options
 
-##############################
-#   Process Initial Scripts  #
-##############################
-
-process_scripts InitialScripts
 
 ##################################
 #   Draw our dialog list window  #

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -61,7 +61,7 @@ fi
 dialogTitle="Your computer setup is underway"
 dialogMessage="Feel free to step away, this could take 30 minutes or more. \n\nYour computer will restart when it's ready for use."
 #^^^dialogIcon="/System/Library/CoreServices/Erase Assistant.app"
-dialogIcon="/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/GenericFolderIcon.icns"
+dialogIcon="/System/Library/CoreServices/KeyboardSetupAssistant.app/Contents/Resources/AppIcon.icns"
 dialogAdditionalOptions=(
     --blurscreen
     --width 900

--- a/ExampleConfigurationFiles/Baseline-BasicExample.mobileconfig
+++ b/ExampleConfigurationFiles/Baseline-BasicExample.mobileconfig
@@ -5,16 +5,19 @@
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<key>PayloadDisplayName</key>
-			<string>Baseline</string>
-			<key>PayloadIdentifier</key>
-			<string>com.secondsonconsulting.baseline.D031FEC3-06B0-497A-BC0A-5D24AE8E91AD</string>
-			<key>PayloadType</key>
-			<string>com.secondsonconsulting.baseline</string>
-			<key>PayloadUUID</key>
-			<string>D031FEC3-06B0-497A-BC0A-5D24AE8E91AD</string>
-			<key>PayloadVersion</key>
-			<integer>1</integer>
+			<key>InitialScripts</key>
+			<array>
+				<dict>
+					<key>Arguments</key>
+					<string>--fdsa</string>
+					<key>DisplayName</key>
+					<string>Initial Example Script</string>
+					<key>MD5</key>
+					<string>e567257026d6032dd232df75fd3ba500</string>
+					<key>ScriptPath</key>
+					<string>ExampleScript.sh</string>
+				</dict>
+			</array>
 			<key>Installomator</key>
 			<array>
 				<dict>
@@ -30,19 +33,6 @@
 					<string>dockutil</string>
 				</dict>
 			</array>
-			<key>Scripts</key>
-			<array>
-				<dict>
-					<key>DisplayName</key>
-					<string>Example Script</string>
-					<key>ScriptPath</key>
-					<string>ExampleScript.sh</string>
-					<key>Arguments</key>
-					<string>--asdf</string>
-					<key>MD5</key>
-					<string>e567257026d6032dd232df75fd3ba500</string>
-				</dict>
-			</array>
 			<key>Packages</key>
 			<array>
 				<dict>
@@ -52,6 +42,29 @@
 					<string>ExamplePKG.pkg</string>
 					<key>TeamID</key>
 					<string>7Q6XP5698G</string>
+				</dict>
+			</array>
+			<key>PayloadDisplayName</key>
+			<string>Baseline</string>
+			<key>PayloadIdentifier</key>
+			<string>com.secondsonconsulting.baseline.D031FEC3-06B0-497A-BC0A-5D24AE8E91AD</string>
+			<key>PayloadType</key>
+			<string>com.secondsonconsulting.baseline</string>
+			<key>PayloadUUID</key>
+			<string>F46B02DA-FF67-481D-B39C-485F8CC9E39B</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>Scripts</key>
+			<array>
+				<dict>
+					<key>Arguments</key>
+					<string>--asdf</string>
+					<key>DisplayName</key>
+					<string>Example Script</string>
+					<key>MD5</key>
+					<string>e567257026d6032dd232df75fd3ba500</string>
+					<key>ScriptPath</key>
+					<string>ExampleScript.sh</string>
 				</dict>
 			</array>
 		</dict>
@@ -69,7 +82,7 @@
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>
-	<string>53C97AF2-0204-476E-BAC9-E805FF698FA3</string>
+	<string>8A016FF5-057E-4F31-9043-9C715F061433</string>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
 </dict>


### PR DESCRIPTION
## 0.5.2 Release Notes
This code will be the upcoming 1.0 release unless a bug or error is identified in the next week.
- Small order of operations change resulting in `InitialScripts` being processed prior to the SwiftDialog list being calculated. Should not affect any existing deployments/configurations, but will give some additional flexibility for advanced setups.
- Changed the default message icon to sidestep a SwiftDialog bug where .app icons don't always show. We're now pointing to the "Keyboard Assistant" icon (nearly identical as the previous "Erase Assistant" icon) and we're pointing directly to an icns file
 - On macOS Monterey this icon looks squared off. If that bothers you, change line 63 to point to whichever icon you wish to use
- Added an `InitialScript` to our example configuration file