### PR TITLE
Baseline.sh: Adjust dialog option if restart is not set

### DIFF
--- a/Baseline.sh
+++ b/Baseline.sh
@@ -944,8 +944,13 @@ function configure_dialog_list_arguments()
     fi
 }
 
+default_message="Feel free to step away, this could take 30 minutes or more."
+if $forceRestart; then
+    default_message+="\n\nYour computer will restart when it's ready for use."
+fi
+
 configure_dialog_list_arguments "--title" "Your computer setup is underway"
-configure_dialog_list_arguments "--message" "Feel free to step away, this could take 30 minutes or more. \n\nYour computer will restart when it's ready for use."
+configure_dialog_list_arguments "--message" "$default_message"
 configure_dialog_list_arguments "--icon" "/System/Library/CoreServices/KeyboardSetupAssistant.app/Contents/Resources/AppIcon.icns"
 configure_dialog_list_arguments "--width" 900
 configure_dialog_list_arguments "--height" 550


### PR DESCRIPTION
Adjusted dialog to match whether `Restart` key is set to False. Logic should match implementation used elsewhere, however can adjust as needed:

* https://github.com/SecondSonConsulting/Baseline/blob/a9f3507343974719aed6d765a1da5f33459c1af4/Baseline.sh#L988-L995