### PR TITLE
Baseline.sh: Add progress bar during setup

### DIFF
--- a/Baseline.sh
+++ b/Baseline.sh
@@ -830,6 +830,10 @@ function build_dialog_json_file()
     done
     /bin/echo "]}" >> $dialogJsonFile
     sleep .1
+
+    # Work-around permission issues for swiftDialog
+    # 'ERROR: File not found : /var/tmp/baselineJson.XXXX'
+    chmod 644 "$dialogJsonFile"
 }
 
 function build_dialog_list_options()

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -161,7 +161,7 @@ function cleanup_and_exit()
     done
 
     kill "$caffeinatepid"
-    dialog_command "quit:" 
+    dialog_command "quit:"
     rm_if_exists "$dialogCommandFile"
     rm_if_exists "$dialogJsonFile"
     if [ "$dryRun" != 1 ] && [ "$cleanupBaselineDirectory" = "true" ] ; then
@@ -196,11 +196,11 @@ function cleanup_and_restart()
     kill "$caffeinatepid"
     # Close dialog window
     dialog_command "quit:"
-    # Delete dialog command file 
+    # Delete dialog command file
     rm_if_exists "$dialogCommandFile"
     # Delete dialog json file
     rm_if_exists "$dialogJsonFile"
-  
+
     # If this isn't a test run, force a restart
     if [ $forceRestart = "false" ]; then
         if  [ $cleanupBaselineDirectory = "true" ]; then
@@ -309,7 +309,7 @@ function install_installomator()
             installomatorInstallAttempts=$((installomatorInstallAttempts+1))
         fi
         # Remove the temporary working directory when done
-        rm_if_exists "$tempDirectory"  
+        rm_if_exists "$tempDirectory"
     done
 }
 
@@ -327,7 +327,7 @@ function wait_for_user()
         if [ "$currentUser" = "root" ] \
             || [ "$currentUser" = "loginwindow" ] \
             || [ "$currentUser" = "_mbsetupuser" ] \
-            || [ -z "$currentUser" ] 
+            || [ -z "$currentUser" ]
         then
         #If we aren't verified yet, wait 1 second and try again
         sleep 1
@@ -360,7 +360,7 @@ function verify_configuration_file()
 {
     #We need to make sure our configuration file is in place. By the time the user logs in, this should have happened.
     debug_message "Verifying configuration file. Failure here probably means an MDM profile hasn't been properly scoped, or there's a problem with the MDM delivering the profile."
-    
+
     #Set timeout variables
     configFileTimeout=600
     configFileWaiting=0
@@ -488,9 +488,9 @@ function build_dialog_array()
 			report_message "No icon set, leaving blank"
 			currentIconPath=""
 		fi
-        
+
         #Generate JSON entry for item
-        #NOTE: We would need to look ahead to determine the last line and omit the ',' on the last line for valid JSON, but Dialog doesn't seem to care.. 
+        #NOTE: We would need to look ahead to determine the last line and omit the ',' on the last line for valid JSON, but Dialog doesn't seem to care..
         dialogListJson+="{\"title\" : \"$currentDisplayName\", \"icon\" : \"$currentIconPath\", \"status\" : \"\"},"
 
         #Done looping. Increase our array value and loop again.
@@ -670,7 +670,7 @@ function process_pkgs()
         currentDisplayName=$($pBuddy -c "Print :Packages:${currentIndex}:DisplayName" "$BaselineConfig")
         #Set the current package path
         currentPKGPath=$($pBuddy -c "Print :Packages:${currentIndex}:PackagePath" "$BaselineConfig")
-        
+
         ##Here is where we begin checking what kind of PKG was defined, and how to process it
         ##The end result of this chunk of code, is that we have a valid path to a PKG on the file system
         ##Else we bail and continue looping to install the next item
@@ -703,7 +703,7 @@ function process_pkgs()
                 debug_message "PKG downloaded successfully: $currentPKGPath downloaded to $currentPKG"
             fi
         fi
-        
+
         # Check if the pkg exists
         if [ -e "$currentPKG" ]; then
             debug_message "PKG found: $currentPKG"
@@ -725,7 +725,7 @@ function process_pkgs()
         ##At this point, the pkg exists on the file system, or we've bailed on this loop.
 
         #Check if there are Arguments defined, and set the variable accordingly
-        if $pBuddy -c "Print :Packages:${currentIndex}:Arguments" "$BaselineConfig" > /dev/null 2>&1; then 
+        if $pBuddy -c "Print :Packages:${currentIndex}:Arguments" "$BaselineConfig" > /dev/null 2>&1; then
             #This pkg has arguments defined
             currentArguments=$($pBuddy -c "Print :Packages:${currentIndex}:Arguments" "$BaselineConfig")
         else
@@ -777,7 +777,7 @@ function process_pkgs()
                 report_message "TeamID of PKG validated: $currentPKG $expectedTeamID"
             fi
         fi
-        
+
         # Check MD5, if a value has been provided
         if [ -n "$expectedMD5" ]; then
             #Get MD5 for the current PKG
@@ -1222,7 +1222,7 @@ done
 
 # Progress Bar will be pulsing until a value is set
 if [ "$displayProgressBar" = "true" ]; then
-    dialog_command "progress: 0"
+    dialog_command "progress: 1"
 fi
 
 process_installomator_labels

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -161,7 +161,7 @@ function cleanup_and_exit()
     done
 
     kill "$caffeinatepid"
-    dialog_command "quit:"
+    dialog_command "quit:" 
     rm_if_exists "$dialogCommandFile"
     rm_if_exists "$dialogJsonFile"
     if [ "$dryRun" != 1 ] && [ "$cleanupBaselineDirectory" = "true" ] ; then
@@ -196,11 +196,11 @@ function cleanup_and_restart()
     kill "$caffeinatepid"
     # Close dialog window
     dialog_command "quit:"
-    # Delete dialog command file
+    # Delete dialog command file 
     rm_if_exists "$dialogCommandFile"
     # Delete dialog json file
     rm_if_exists "$dialogJsonFile"
-
+ 
     # If this isn't a test run, force a restart
     if [ $forceRestart = "false" ]; then
         if  [ $cleanupBaselineDirectory = "true" ]; then

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -1091,7 +1091,7 @@ configure_dialog_list_arguments "--height" 550
 configure_dialog_list_arguments "--quitkey" ']'
 
 if [ "$displayProgressBar" = "true" ]; then
-    configure_dialog_list_arguments "--progressbar" "0"
+    configure_dialog_list_arguments "--progress"
     if [ "$displayProgressBarLabel" = "true" ]; then
         configure_dialog_list_arguments "--progresstext" "Starting shortly..."
     fi

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -596,7 +596,11 @@ function process_scripts()
 
         #Update the dialog window so that this item shows as "pending"
         dialog_command "listitem: title: $currentDisplayName, status: wait"
-        set_progressbar_text "Running: $currentDisplayName"
+
+        #Only set the progress label if we're processing Scripts, not InitialScripts since users won't see those
+        if [ "$1" = "Scripts" ]; then
+            set_progressbar_text "Running: $currentDisplayName"
+        fi
 
         #Call our script with our desired options. Default options first, so that they can be overriden by "currentArguments"
         "$currentScript" ${currentArgumentArray[@]} >> "$ScriptOutputLog" 2>&1

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -891,7 +891,7 @@ function increment_progress_bar()
 
 function set_progressbar_text()
 {
-    if [ "$displayProgressBar" != "true" ]; then
+    if [ "$displayProgressBarLabel" != "true" ]; then
         return
     fi
 

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -200,7 +200,7 @@ function cleanup_and_restart()
     rm_if_exists "$dialogCommandFile"
     # Delete dialog json file
     rm_if_exists "$dialogJsonFile"
- 
+  
     # If this isn't a test run, force a restart
     if [ $forceRestart = "false" ]; then
         if  [ $cleanupBaselineDirectory = "true" ]; then
@@ -309,7 +309,7 @@ function install_installomator()
             installomatorInstallAttempts=$((installomatorInstallAttempts+1))
         fi
         # Remove the temporary working directory when done
-        rm_if_exists "$tempDirectory"
+        rm_if_exists "$tempDirectory" 
     done
 }
 
@@ -327,7 +327,7 @@ function wait_for_user()
         if [ "$currentUser" = "root" ] \
             || [ "$currentUser" = "loginwindow" ] \
             || [ "$currentUser" = "_mbsetupuser" ] \
-            || [ -z "$currentUser" ]
+            || [ -z "$currentUser" ] 
         then
         #If we aren't verified yet, wait 1 second and try again
         sleep 1
@@ -360,7 +360,7 @@ function verify_configuration_file()
 {
     #We need to make sure our configuration file is in place. By the time the user logs in, this should have happened.
     debug_message "Verifying configuration file. Failure here probably means an MDM profile hasn't been properly scoped, or there's a problem with the MDM delivering the profile."
-
+	
     #Set timeout variables
     configFileTimeout=600
     configFileWaiting=0
@@ -488,9 +488,9 @@ function build_dialog_array()
 			report_message "No icon set, leaving blank"
 			currentIconPath=""
 		fi
-
+		
         #Generate JSON entry for item
-        #NOTE: We would need to look ahead to determine the last line and omit the ',' on the last line for valid JSON, but Dialog doesn't seem to care..
+        #NOTE: We would need to look ahead to determine the last line and omit the ',' on the last line for valid JSON, but Dialog doesn't seem to care.. 
         dialogListJson+="{\"title\" : \"$currentDisplayName\", \"icon\" : \"$currentIconPath\", \"status\" : \"\"},"
 
         #Done looping. Increase our array value and loop again.
@@ -670,7 +670,7 @@ function process_pkgs()
         currentDisplayName=$($pBuddy -c "Print :Packages:${currentIndex}:DisplayName" "$BaselineConfig")
         #Set the current package path
         currentPKGPath=$($pBuddy -c "Print :Packages:${currentIndex}:PackagePath" "$BaselineConfig")
-
+		
         ##Here is where we begin checking what kind of PKG was defined, and how to process it
         ##The end result of this chunk of code, is that we have a valid path to a PKG on the file system
         ##Else we bail and continue looping to install the next item
@@ -703,7 +703,7 @@ function process_pkgs()
                 debug_message "PKG downloaded successfully: $currentPKGPath downloaded to $currentPKG"
             fi
         fi
-
+		
         # Check if the pkg exists
         if [ -e "$currentPKG" ]; then
             debug_message "PKG found: $currentPKG"

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -422,6 +422,7 @@ function process_installomator_labels()
         currentDisplayName=$($pBuddy -c "Print :Installomator:${currentIndex}:DisplayName" "$BaselineConfig")
         #Update the dialog window so that this item shows as "pending"
         dialog_command "listitem: title: $currentDisplayName, status: wait"
+        set_progressbar_text "Installing: $currentDisplayName"
         #Call installomator with our desired options. Default options first, so that they can be overriden by "currentArguments"
         $installomatorPath $currentLabel ${defaultInstallomatorOptions[@]} $currentArguments > /dev/null 2>&1
         installomatorExitCode=$?
@@ -435,6 +436,7 @@ function process_installomator_labels()
             successList+=("$currentDisplayName")
        fi
         currentIndex=$((currentIndex+1))
+        increment_progress_bar
     done
 }
 
@@ -594,6 +596,7 @@ function process_scripts()
 
         #Update the dialog window so that this item shows as "pending"
         dialog_command "listitem: title: $currentDisplayName, status: wait"
+        set_progressbar_text "Running: $currentDisplayName"
 
         #Call our script with our desired options. Default options first, so that they can be overriden by "currentArguments"
         "$currentScript" ${currentArgumentArray[@]} >> "$ScriptOutputLog" 2>&1
@@ -610,6 +613,11 @@ function process_scripts()
 
        #Iterate index for next loop
         currentIndex=$((currentIndex+1))
+
+        #Only increment the progress bar if we're processing Scripts, not InitialScripts since users won't see those
+        if [ "$1" = "Scripts" ]; then
+            increment_progress_bar
+        fi
     done
 }
 
@@ -677,6 +685,7 @@ function process_pkgs()
                 report_message "ERROR: PKG failed to download: $currentPKGPath"
                 # Iterate the index up one
                 currentIndex=$((currentIndex+1))
+                increment_progress_bar
                 # Report the fail
                 dialog_command "listitem: title: $currentDisplayName, status: fail"
                 # Bail this pass through the while loop and continue processing next item
@@ -700,6 +709,7 @@ function process_pkgs()
             dialog_command "listitem: title: $currentDisplayName, status: fail"
             failList+=("$currentDisplayName")
             currentIndex=$((currentIndex+1))
+            increment_progress_bar
             continue
         fi
 
@@ -735,7 +745,8 @@ function process_pkgs()
         fi
         #Update the dialog window so that this item shows as "pending"
         dialog_command "listitem: title: $currentDisplayName, status: wait"
-        
+        set_progressbar_text "Installing: $currentDisplayName"
+
         ## Package validation happens here
         # Check TeamID, if a value has been provided
         if [ -n "$expectedTeamID" ]; then
@@ -748,6 +759,7 @@ function process_pkgs()
                 failList+=("$currentDisplayName")
                 # Iterate the index up one
                 currentIndex=$((currentIndex+1))
+                increment_progress_bar
                 # Report the fail
                 dialog_command "listitem: title: $currentDisplayName, status: fail"
                 # Bail this pass through the while loop and continue processing next item
@@ -768,6 +780,7 @@ function process_pkgs()
                 failList+=("$currentDisplayName")
                 # Iterate the index up one
                 currentIndex=$((currentIndex+1))
+                increment_progress_bar
                 # Report the fail
                 dialog_command "listitem: title: $currentDisplayName, status: fail"
                 # Bail this pass through the while loop and continue processing next item
@@ -794,6 +807,7 @@ function process_pkgs()
         debug_message "Output of the install package command: $pkgInstallerOutput"
         # Iterate to the next index item, and continue our loop
         currentIndex=$((currentIndex+1))
+        increment_progress_bar
     done
 }
 

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -309,7 +309,7 @@ function install_installomator()
             installomatorInstallAttempts=$((installomatorInstallAttempts+1))
         fi
         # Remove the temporary working directory when done
-        rm_if_exists "$tempDirectory" 
+        rm_if_exists "$tempDirectory"  
     done
 }
 
@@ -360,7 +360,7 @@ function verify_configuration_file()
 {
     #We need to make sure our configuration file is in place. By the time the user logs in, this should have happened.
     debug_message "Verifying configuration file. Failure here probably means an MDM profile hasn't been properly scoped, or there's a problem with the MDM delivering the profile."
-	
+  
     #Set timeout variables
     configFileTimeout=600
     configFileWaiting=0
@@ -488,7 +488,7 @@ function build_dialog_array()
 			report_message "No icon set, leaving blank"
 			currentIconPath=""
 		fi
-		
+	
         #Generate JSON entry for item
         #NOTE: We would need to look ahead to determine the last line and omit the ',' on the last line for valid JSON, but Dialog doesn't seem to care.. 
         dialogListJson+="{\"title\" : \"$currentDisplayName\", \"icon\" : \"$currentIconPath\", \"status\" : \"\"},"
@@ -703,7 +703,7 @@ function process_pkgs()
                 debug_message "PKG downloaded successfully: $currentPKGPath downloaded to $currentPKG"
             fi
         fi
-		
+	
         # Check if the pkg exists
         if [ -e "$currentPKG" ]; then
             debug_message "PKG found: $currentPKG"
@@ -725,7 +725,7 @@ function process_pkgs()
         ##At this point, the pkg exists on the file system, or we've bailed on this loop.
 
         #Check if there are Arguments defined, and set the variable accordingly
-        if $pBuddy -c "Print :Packages:${currentIndex}:Arguments" "$BaselineConfig" > /dev/null 2>&1; then
+        if $pBuddy -c "Print :Packages:${currentIndex}:Arguments" "$BaselineConfig" > /dev/null 2>&1; then 
             #This pkg has arguments defined
             currentArguments=$($pBuddy -c "Print :Packages:${currentIndex}:Arguments" "$BaselineConfig")
         else
@@ -777,7 +777,7 @@ function process_pkgs()
                 report_message "TeamID of PKG validated: $currentPKG $expectedTeamID"
             fi
         fi
-
+		
         # Check MD5, if a value has been provided
         if [ -n "$expectedMD5" ]; then
             #Get MD5 for the current PKG

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -843,7 +843,7 @@ function check_restart_option()
     fi
 }
 
-function check_progress_option()
+function check_progress_options()
 {
     # Set variable for whether or not we'll display a progress bar. Defaults to 'false'
     displayProgressBarSetting=$($pBuddy -c "Print :DisplayProgressBar" "$BaselineConfig")
@@ -852,6 +852,15 @@ function check_progress_option()
         displayProgressBar="true"
     else
         displayProgressBar="false"
+    fi
+
+    # Set variable for whether or not we'll display a progress bar label. Defaults to 'false'
+    displayProgressBarLabelSetting=$($pBuddy -c "Print :DisplayProgressBarLabel" "$BaselineConfig")
+
+    if  [ $displayProgressBarLabelSetting = "true" ]; then
+        displayProgressBarLabel="true"
+    else
+        displayProgressBarLabel="false"
     fi
 }
 
@@ -982,6 +991,7 @@ progressBarTotal=0
 
 # Initiate bools
 displayProgressBar="false"
+displayProgressBarLabel="false"
 
 ##############################
 #   Process Initial Scripts  #
@@ -1004,7 +1014,7 @@ fi
 check_restart_option
 
 # Check if we should display a progress bar under the UI
-check_progress_option
+check_progress_options
 
 
 ######################################
@@ -1056,6 +1066,13 @@ configure_dialog_list_arguments "--icon" "/System/Library/CoreServices/KeyboardS
 configure_dialog_list_arguments "--width" 900
 configure_dialog_list_arguments "--height" 550
 configure_dialog_list_arguments "--quitkey" ']'
+
+if [ "$displayProgressBar" = "true" ]; then
+    configure_dialog_list_arguments "--progressbar" "0"
+    if [ "$displayProgressBarLabel" = "true" ]; then
+        configure_dialog_list_arguments "--progresstext" "Starting shortly..."
+    fi
+fi
 
 #########################################
 #   Configure Success Customizations    #

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -493,6 +493,7 @@ function build_dialog_array()
 
         #Done looping. Increase our array value and loop again.
         index=$((index+1))
+        progressBarTotal=$((progressBarTotal+1))
     done
 }
 
@@ -842,6 +843,38 @@ function check_restart_option()
     fi
 }
 
+function check_progress_option()
+{
+    # Set variable for whether or not we'll display a progress bar. Defaults to 'false'
+    displayProgressBarSetting=$($pBuddy -c "Print :DisplayProgressBar" "$BaselineConfig")
+
+    if  [ $displayProgressBarSetting = "true" ]; then
+        displayProgressBar="true"
+    else
+        displayProgressBar="false"
+    fi
+}
+
+function increment_progress_bar()
+{
+    if [ "$displayProgressBar" != "true" ]; then
+        return
+    fi
+
+    progressBarValue=$((progressBarValue+1))
+    progressBarPercentage=$((progressBarValue*100/progressBarTotal))
+    dialog_command "progress: $progressBarPercentage"
+}
+
+function set_progressbar_text()
+{
+    if [ "$displayProgressBar" != "true" ]; then
+        return
+    fi
+
+    dialog_command "progresstext: $1"
+}
+
 #############################################
 #   Configure Default Installomator Options #
 #############################################
@@ -939,6 +972,17 @@ scriptArguments=()
 pkgsToInstall=()
 pkgValidations=()
 
+######################
+# Integers and Bools #
+######################
+
+# Initiate integers
+progressBarValue=0
+progressBarTotal=0
+
+# Initiate bools
+displayProgressBar="false"
+
 ##############################
 #   Process Initial Scripts  #
 ##############################
@@ -958,6 +1002,9 @@ fi
 #######################
 # Check if we are going to restart. This has to be here, because the Dialog customizations depend on it
 check_restart_option
+
+# Check if we should display a progress bar under the UI
+check_progress_option
 
 
 ######################################

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -360,7 +360,7 @@ function verify_configuration_file()
 {
     #We need to make sure our configuration file is in place. By the time the user logs in, this should have happened.
     debug_message "Verifying configuration file. Failure here probably means an MDM profile hasn't been properly scoped, or there's a problem with the MDM delivering the profile."
-  
+    
     #Set timeout variables
     configFileTimeout=600
     configFileWaiting=0
@@ -488,7 +488,7 @@ function build_dialog_array()
 			report_message "No icon set, leaving blank"
 			currentIconPath=""
 		fi
-	
+        
         #Generate JSON entry for item
         #NOTE: We would need to look ahead to determine the last line and omit the ',' on the last line for valid JSON, but Dialog doesn't seem to care.. 
         dialogListJson+="{\"title\" : \"$currentDisplayName\", \"icon\" : \"$currentIconPath\", \"status\" : \"\"},"
@@ -670,7 +670,7 @@ function process_pkgs()
         currentDisplayName=$($pBuddy -c "Print :Packages:${currentIndex}:DisplayName" "$BaselineConfig")
         #Set the current package path
         currentPKGPath=$($pBuddy -c "Print :Packages:${currentIndex}:PackagePath" "$BaselineConfig")
-		
+        
         ##Here is where we begin checking what kind of PKG was defined, and how to process it
         ##The end result of this chunk of code, is that we have a valid path to a PKG on the file system
         ##Else we bail and continue looping to install the next item
@@ -703,7 +703,7 @@ function process_pkgs()
                 debug_message "PKG downloaded successfully: $currentPKGPath downloaded to $currentPKG"
             fi
         fi
-	
+        
         # Check if the pkg exists
         if [ -e "$currentPKG" ]; then
             debug_message "PKG found: $currentPKG"
@@ -777,7 +777,7 @@ function process_pkgs()
                 report_message "TeamID of PKG validated: $currentPKG $expectedTeamID"
             fi
         fi
-		
+        
         # Check MD5, if a value has been provided
         if [ -n "$expectedMD5" ]; then
             #Get MD5 for the current PKG

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -1220,6 +1220,11 @@ done
 #   Install the things  #
 #########################
 
+# Progress Bar will be pulsing until a value is set
+if [ "$displayProgressBar" = "true" ]; then
+    dialog_command "progress: 0"
+fi
+
 process_installomator_labels
 
 process_pkgs

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -491,7 +491,7 @@ function build_dialog_array()
         
         #Generate JSON entry for item
         #NOTE: We would need to look ahead to determine the last line and omit the ',' on the last line for valid JSON, but Dialog doesn't seem to care.. 
-        dialogListJson+="{\"title\" : \"$currentDisplayName\", \"icon\" : \"$currentIconPath\", \"status\" : \"wait\"},"
+        dialogListJson+="{\"title\" : \"$currentDisplayName\", \"icon\" : \"$currentIconPath\", \"status\" : \"\"},"
 
         #Done looping. Increase our array value and loop again.
         index=$((index+1))

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -553,6 +553,7 @@ function process_scripts()
             report_message "ERROR: Script does not exist: $currentScript"
             # Iterate the index up one
             currentIndex=$((currentIndex+1))
+            increment_progress_bar
             # Report the fail
             dialog_command "listitem: title: $currentDisplayName, status: fail"
             failList+=("$currentDisplayName")
@@ -571,6 +572,10 @@ function process_scripts()
                 report_message "ERROR: MD5 value mismatch. Expected: $expectedMD5 Actual: $actualMD5"
                 # Iterate the index up one
                 currentIndex=$((currentIndex+1))
+                # Only increment the progress bar if we're processing Scripts, not InitialScripts since users won't see those
+                if [ "$1" = "Scripts" ]; then
+                    increment_progress_bar
+                fi
                 # Report the fail
                 dialog_command "listitem: title: $currentDisplayName, status: fail"
                 failList+=("$currentDisplayName")

--- a/ProfileManifest/com.secondsonconsulting.baseline.plist
+++ b/ProfileManifest/com.secondsonconsulting.baseline.plist
@@ -417,6 +417,16 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
+			<string>This setting controls whether Baseline displays the current item being processed under the progress bar. Default is false.</string>
+			<key>pfm_name</key>
+			<string>DisplayProgressBarLabel</string>
+			<key>pfm_title</key>
+			<string>DisplayProgressBarLabel</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
 			<string>SwiftDialog options for the primary Baseline progress list window.</string>
 			<key>pfm_name</key>
 			<string>DialogListOptions</string>

--- a/ProfileManifest/com.secondsonconsulting.baseline.plist
+++ b/ProfileManifest/com.secondsonconsulting.baseline.plist
@@ -407,6 +407,16 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
+			<string>This setting controls whether Baseline displays a progress bar. Default is false.</string>
+			<key>pfm_name</key>
+			<string>DisplayProgressBar</string>
+			<key>pfm_title</key>
+			<string>DisplayProgressBar</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
 			<string>SwiftDialog options for the primary Baseline progress list window.</string>
 			<key>pfm_name</key>
 			<string>DialogListOptions</string>


### PR DESCRIPTION
Implements 2 new keys for the config:
* `DisplayProgressBar`: Control whether a progress bar is shown
  * Defaults to disabled if not configured 
* `DisplayProgressBarLabel`: Control whether currently processed item is shown under the progress bar
  * Defaults to disabled if not configured

Additionally resolves following regressions:
* swiftDialog unable to start
  * Resolved by adjusting permissions to  `dialogJsonFile` (`chmod 644`)
* Queued items showing as in-progress
  * Resolved by removing the default `wait` in JSON generation

------

Logic for `DisplayProgressBarLabel` is that if a user specifies a custom `--video` argument, the list view will be obstructed by the provided video in swiftDialog. The main reason we'd want video support is if clients would want to present onboarding videos while the machine is being setup.

------

Sample Photo:

| Progress Bar and Label, Video | Progress Bar and Label, Installomator | Progress Bar and Label, Scripts |
| :--- |  :--- |  :--- | 
| <img width="1000" alt="Screenshot 2023-08-16 at 11 47 47 AM" src="https://github.com/SecondSonConsulting/Baseline/assets/48863253/a3cc2a2d-cdc5-453f-bfb3-910148cd298f"> | <img width="1000" alt="Screenshot 2023-08-16 at 1 51 16 PM" src="https://github.com/SecondSonConsulting/Baseline/assets/48863253/8737e24f-09d1-4649-aa4d-062a577760ca"> |  <img width="1000" alt="Screenshot 2023-08-16 at 1 53 30 PM" src="https://github.com/SecondSonConsulting/Baseline/assets/48863253/d311167e-c660-4636-b8f8-d9764159faec"> |
