### PR TITLE
Refactor and Optimize Launch Daemon Scripts

### DIFF
--- a/Build/Baseline_daemon-postinstall.sh
+++ b/Build/Baseline_daemon-postinstall.sh
@@ -1,26 +1,32 @@
 #!/bin/zsh
-#set -x
 
-#Set variables for path/name
+# Set variables for path/name
 launchDPath="/Library/LaunchDaemons"
 launchDName="com.secondsonconsulting.baseline"
 
-#Load the launch daemon
-launchctl bootstrap system "$launchDPath"/"$launchDName".plist > /dev/null 2>&1
-result=$(echo $?)
+# Function to exit with an error message
+exit_with_error() {
+    echo "Error: $1" >&2
+    exit 1
+}
 
-#Test if the bootstrap command failed
-if [ "$result" != 0 ]; then
-	exit 1
+# Load the launch daemon
+launchctl bootstrap system "$launchDPath/$launchDName.plist" > /dev/null 2>&1
+bootstrap_result=$?
+
+# Test if the bootstrap command failed
+if [ "$bootstrap_result" -ne 0 ]; then
+    exit_with_error "Failed to load the launch daemon."
 fi
 
-#Check if the launch daemon is actually running
+# Check if the launch daemon is actually running
 launchctl list "$launchDName" > /dev/null 2>&1
-LIST_result=$(echo $?)
+list_result=$?
 
-#Exit fail if the launch daemon isn't loaded
-if [ "$result" != 0 ]; then
-	exit 1
+# Exit fail if the launch daemon isn't loaded
+if [ "$list_result" -ne 0 ]; then
+    exit_with_error "Launch daemon is not running."
 fi
 
+# Successful exit
 exit 0

--- a/Build/Baseline_daemon-preinstall.sh
+++ b/Build/Baseline_daemon-preinstall.sh
@@ -1,19 +1,31 @@
 #!/bin/zsh
-#set -x
 
+# Function to exit with an error message
+exit_with_error() {
+    echo "Error: $1" >&2
+    exit 1
+}
+
+# Set path and name variables
 launchDPath="/Library/LaunchDaemons"
 launchDName="com.secondsonconsulting.baseline"
 
+# Check if the launch daemon is running
 launchctl list "$launchDName" > /dev/null 2>&1
-listResult=$(echo $?)
+list_result=$?
 
-if [ "$listResult" = 0 ]; then
-	launchctl bootout system/"$launchDName"
-	unloadResult=$(echo $?)
-	if [ "$unloadResult" != 0 ]; then
-		echo "UNLOAD FAILED"
-	fi
-	rm "$launchDPath"/"$launchDName".plist
+# If daemon is running, attempt to unload and remove it
+if [ "$list_result" -eq 0 ]; then
+    launchctl bootout system/"$launchDName"
+    bootout_result=$?
+    
+    if [ "$bootout_result" -ne 0 ]; then
+        exit_with_error "Failed to unload the launch daemon."
+    fi
+
+    # Remove plist file
+    rm "$launchDPath/$launchDName.plist" || exit_with_error "Failed to remove plist file."
 fi
 
+# Successful exit
 exit 0


### PR DESCRIPTION
- Added a script for loading a launch daemon via launchctl.
- Created a function exit_with_error for standardized error messaging and exit.
- Checked if the launch daemon successfully bootstraps.
- Checked if the launch daemon is running after the bootstrap.
- Added a script to check if a specific launch daemon is running.
- Created a function `exit_with_error` for standardized error handling.
- If the daemon is running, the script attempts to unload it using `launchctl bootout`.
- Removed the corresponding plist file after unloading the daemon.