### PR TITLE
added FinalScripts function

### DIFF
--- a/Baseline.sh
+++ b/Baseline.sh
@@ -599,7 +599,6 @@ function process_scripts(){
     while $pBuddy -c "Print :${1}:${currentIndex}" "$BaselineConfig" > /dev/null 2>&1; do
         check_for_bail_out
         #Unset variables for next loop
-        unset asUser
         unset useVerboseJamf
         unset jamfVerbosePID
         unset expectedMD5
@@ -1957,6 +1956,8 @@ fi
 if [ "$dryRun" = true ]; then
     sleep 5
 fi
+
+process_scripts FinalScripts
 
 #Close our running dialog window
 dialog_command "quit:"

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -1957,10 +1957,10 @@ if [ "$dryRun" = true ]; then
     sleep 5
 fi
 
-process_scripts FinalScripts
-
 #Close our running dialog window
 dialog_command "quit:"
+
+process_scripts FinalScripts
 
 #Do final script swiftDialog stuff
 #If the failList is empty, this means success

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -1895,7 +1895,7 @@ build_dialog_list_options
 #Create our initial Dialog Window. Do this in an "until" loop, and attempts 10 times before exiting in case it fails to launch for some reason
 dialogAttemptCount=1
 if ! $silentModeEnabled; then
-    until pgrep -q -x "Dialog"; do
+    until pgrep -q -f "$dialogAppPath.* --commandfile $dialogCommandFile --jsonfile $dialogJsonFile"; do
         if [ "$dialogAttemptCount" -le 10 ]; then
             ${finalListCommand[@]} \
             --commandfile "$dialogCommandFile" \

--- a/ProfileManifest/README.md
+++ b/ProfileManifest/README.md
@@ -6,4 +6,4 @@ For JSONs or Manifests to use with Beta features, check this folder in the `dev`
 
 [The office ProfileManifest repository is the proper place to get the latest public release.](https://github.com/ProfileCreator/ProfileManifests/blob/master/Manifests/ManagedPreferencesApplications/com.secondsonconsulting.baseline.plist)
 
-[Jamf JSON Schema](https://github.com/ProfileCreator/ProfileManifests/blob/master/Manifests/ManagedPreferencesApplications/com.secondsonconsulting.baseline.plist)
+[Jamf JSON Schema](https://github.com/Jamf-Custom-Profile-Schemas/ProfileManifestsMirror/blob/main/manifests/ManagedPreferencesApplications/com.secondsonconsulting.baseline.json)

--- a/ProfileManifest/com.secondsonconsulting.baseline.json
+++ b/ProfileManifest/com.secondsonconsulting.baseline.json
@@ -155,11 +155,6 @@
                         "title": "Arguments",
                         "description": "Arguments you want to pass to the script when it is run."
                     },
-                    "AsUser": {
-                        "type": "boolean",
-                        "title": "As User",
-                        "description": "Run script in the user context."
-                    },
                     "Icon": {
                         "type": "string",
                         "title": "Icon",
@@ -200,6 +195,34 @@
                         "type": "string",
                         "title": "Subtitle",
                         "description": "The subtitle text to appear on this line item."
+                    }
+                }
+            },
+            "FinalScripts": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "DisplayName": {
+                            "type": "string",
+                            "title": "Display Name",
+                            "description": "The name you want to appear SwiftDialog and logs. Final Scripts will only be shown to the user if the item Fails."
+                        },
+                        "ScriptPath": {
+                            "type": "string",
+                            "title": "Script Path",
+                            "description": "A path to the script you want to run. Can be a local file path or a URL."
+                        },
+                        "MD5": {
+                            "type": "string",
+                            "title": "MD5",
+                            "description": "The expected MD5 of the script being run."
+                        },
+                        "Arguments": {
+                            "type": "string",
+                            "title": "Arguments",
+                            "description": "Arguments you want to pass to the script when it is run."
+                        }
                     }
                 }
             },

--- a/ProfileManifest/com.secondsonconsulting.baseline.json
+++ b/ProfileManifest/com.secondsonconsulting.baseline.json
@@ -17,6 +17,11 @@
                         "title": "Script Path",
                         "description": "A path to the script you want to run. Can be a local file path or a URL."
                     },
+                    "SHA256": {
+                        "type": "string",
+                        "title": "SHA256",
+                        "description": "The expected SHA256 of the script being run."
+                    },
                     "MD5": {
                         "type": "string",
                         "title": "MD5",
@@ -89,6 +94,11 @@
                         "title": "TeamID",
                         "description": "The expected TeamID of the package being installed."
                     },
+                    "SHA256": {
+                        "type": "string",
+                        "title": "SHA256",
+                        "description": "The expected SHA256 of the package being installed."
+                    },
                     "MD5": {
                         "type": "string",
                         "title": "MD5",
@@ -129,6 +139,11 @@
                         "type": "string",
                         "title": "Script Path",
                         "description": "A path to the script you want to run. Can be a local file path or a URL."
+                    },
+                    "SHA256": {
+                        "type": "string",
+                        "title": "SHA256",
+                        "description": "The expected SHA256 of the script being run."
                     },
                     "MD5": {
                         "type": "string",

--- a/ProfileManifest/com.secondsonconsulting.baseline.plist
+++ b/ProfileManifest/com.secondsonconsulting.baseline.plist
@@ -588,6 +588,66 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>array</string>
 		</dict>
 		<dict>
+			<key>pfm_description</key>
+			<string>Define scripts that are run just before completion dialogs. For reporting webhooks, cleanup tasks, etc.</string>
+			<key>pfm_name</key>
+			<string>FinalScripts</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_description</key>
+							<string>The name you want to appear SwiftDialog and logs. Final Scripts will only be shown to the user if the item Fails.</string>
+							<key>pfm_name</key>
+							<string>DisplayName</string>
+							<key>pfm_title</key>
+							<string>Display Name</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>A path to the script you want to run. Can be a local file path or a URL.</string>
+							<key>pfm_name</key>
+							<string>ScriptPath</string>
+							<key>pfm_title</key>
+							<string>Script Path</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>The expected MD5 of the script being run.</string>
+							<key>pfm_name</key>
+							<string>MD5</string>
+							<key>pfm_title</key>
+							<string>MD5</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>Arguments you want to pass to the script when it is run.</string>
+							<key>pfm_name</key>
+							<string>Arguments</string>
+							<key>pfm_title</key>
+							<string>Arguments</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+					</array>
+					<key>pfm_type</key>
+					<string>dictionary</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>InitialScripts</string>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+		<dict>
 			<key>pfm_app_min</key>
 			<string>2.2</string>
 			<key>pfm_description</key>

--- a/ProfileManifest/com.secondsonconsulting.baseline.plist
+++ b/ProfileManifest/com.secondsonconsulting.baseline.plist
@@ -433,16 +433,6 @@ A profile can consist of payloads with different version numbers. For example, c
 							<key>pfm_default</key>
 							<false/>
 							<key>pfm_description</key>
-							<string>Run script in the user context.</string>
-							<key>pfm_name</key>
-							<string>AsUser</string>
-							<key>pfm_title</key>
-							<string>As User</string>
-							<key>pfm_type</key>
-							<string>boolean</string>
-						</dict>
-						<dict>
-							<key>pfm_description</key>
 							<string>The icon you want to appear in the SwiftDialog menu as this script is run. Can be a URL or local file path.</string>
 							<key>pfm_name</key>
 							<string>Icon</string>
@@ -534,6 +524,66 @@ A profile can consist of payloads with different version numbers. For example, c
 			</array>
 			<key>pfm_title</key>
 			<string>WaitFor</string>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Define scripts that are run just before completion dialogs. For reporting webhooks, cleanup tasks, etc.</string>
+			<key>pfm_name</key>
+			<string>FinalScripts</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_description</key>
+							<string>The name you want to appear SwiftDialog and logs. Final Scripts will only be shown to the user if the item Fails.</string>
+							<key>pfm_name</key>
+							<string>DisplayName</string>
+							<key>pfm_title</key>
+							<string>Display Name</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>A path to the script you want to run. Can be a local file path or a URL.</string>
+							<key>pfm_name</key>
+							<string>ScriptPath</string>
+							<key>pfm_title</key>
+							<string>Script Path</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>The expected MD5 of the script being run.</string>
+							<key>pfm_name</key>
+							<string>MD5</string>
+							<key>pfm_title</key>
+							<string>MD5</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>Arguments you want to pass to the script when it is run.</string>
+							<key>pfm_name</key>
+							<string>Arguments</string>
+							<key>pfm_title</key>
+							<string>Arguments</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+					</array>
+					<key>pfm_type</key>
+					<string>dictionary</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>InitialScripts</string>
 			<key>pfm_type</key>
 			<string>array</string>
 		</dict>

--- a/ProfileManifest/com.secondsonconsulting.baseline.plist
+++ b/ProfileManifest/com.secondsonconsulting.baseline.plist
@@ -430,6 +430,8 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>string</string>
 						</dict>
 						<dict>
+							<key>pfm_default</key>
+							<false/>
 							<key>pfm_description</key>
 							<string>Run script in the user context.</string>
 							<key>pfm_name</key>

--- a/ProfileManifest/com.secondsonconsulting.baseline.plist
+++ b/ProfileManifest/com.secondsonconsulting.baseline.plist
@@ -157,6 +157,16 @@ A profile can consist of payloads with different version numbers. For example, c
 						</dict>
 						<dict>
 							<key>pfm_description</key>
+							<string>The expected SHA256 of the script being run.</string>
+							<key>pfm_name</key>
+							<string>SHA256</string>
+							<key>pfm_title</key>
+							<string>SHA256</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
 							<string>The expected MD5 of the script being run.</string>
 							<key>pfm_name</key>
 							<string>MD5</string>
@@ -299,6 +309,16 @@ A profile can consist of payloads with different version numbers. For example, c
 						</dict>
 						<dict>
 							<key>pfm_description</key>
+							<string>The expected SHA256 of the package being installed.</string>
+							<key>pfm_name</key>
+							<string>SHA256</string>
+							<key>pfm_title</key>
+							<string>SHA256</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
 							<string>The expected MD5 of the package being installed.</string>
 							<key>pfm_name</key>
 							<string>MD5</string>
@@ -376,6 +396,16 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>ScriptPath</string>
 							<key>pfm_title</key>
 							<string>Script Path</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>The expected SHA256 of the script being run.</string>
+							<key>pfm_name</key>
+							<string>SHA256</string>
+							<key>pfm_title</key>
+							<string>SHA256</string>
 							<key>pfm_type</key>
 							<string>string</string>
 						</dict>


### PR DESCRIPTION
Fairly simple add here: Added FinalScripts section to config profile and JSON schema. Added in the additional process_scripts function call before the dialog_command: "quit:" line. Seems to work as intended with test script. Also tested with a long sleep in the script, and it does just hang on the list screen, so keeping script run times short is indeed a good idea or it will be kind of an awkward lag for the end user. Failure shows up in the failed list if script fails. Basically this is just InitialScripts but at the end. 


