### PR TITLE
Wait for updates

### DIFF
--- a/Baseline.sh
+++ b/Baseline.sh
@@ -72,7 +72,7 @@ installomatorPath="/usr/local/Installomator/Installomator.sh"
 dialogCommandFile=$(mktemp "${BaselineTempDir}/baselineDialog.XXXXXX")
 dialogJsonFile=$(mktemp "${BaselineTempDir}/baselineJson.XXXX")
 expectedDialogTeamID="PWA5E9TQ59"
-defaultWaitForTimeout=300
+defaultWaitForTimeout=600
 
 # Path to the Jamf log file
 jamfLogFile="/private/var/log/jamf.log"


### PR DESCRIPTION
Updated WaitFor feature so that items will check off as successful anytime they arrive, not just after all other items are processed

WaitForTimout now starts earlier in the Baseline process. The default value is now 600 seconds (up from 300) to account for this.