### PR TITLE
2.3beta2

### DIFF
--- a/Baseline.sh
+++ b/Baseline.sh
@@ -1979,10 +1979,23 @@ if [ "$dryRun" = true ]; then
     sleep 5
 fi
 
-#Close our running dialog window
-dialog_command "quit:"
+# Check if we are closing the list window before running Final Scripts
+if $pBuddy -c "Print :CloseListBeforeFinalScripts" "$BaselineConfig" > /dev/null 2>&1; then
+    closeListBeforeFinalScripts=$($pBuddy -c "Print :CloseListBeforeFinalScripts" "$BaselineConfig")
+else
+    closeListBeforeFinalScripts="false"
+fi
 
-process_scripts FinalScripts
+log_message "CloseListBeforeFinalScripts: $closeListBeforeFinalScripts"
+
+# If we are closing the List window before running Final Scripts
+if [[ "$closeListBeforeFinalScripts" == "true" ]]; then
+    dialog_command "quit:"
+    process_scripts FinalScripts
+else
+    process_scripts FinalScripts
+    dialog_command "quit:"
+fi
 
 #Do final script swiftDialog stuff
 #If the failList is empty, this means success

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -6,7 +6,7 @@ set -x
 #   @BigMacAdmin on the MacAdmins Slack
 #   trevor@secondsonconsulting.com
 
-scriptVersion="2.3beta1"
+scriptVersion="2.3beta2"
 
 # MIT License
 # 

--- a/ProfileManifest/com.secondsonconsulting.baseline.plist
+++ b/ProfileManifest/com.secondsonconsulting.baseline.plist
@@ -547,7 +547,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Define scripts that are run just before completion dialogs. For reporting webhooks, cleanup tasks, etc.</string>
+			<string>Define scripts that are run just before completion dialogs. For reporting webhooks, cleanup tasks, etc. Similar to InitialScripts, these items do not appear on the List View.</string>
 			<key>pfm_name</key>
 			<string>FinalScripts</string>
 			<key>pfm_subkeys</key>
@@ -769,6 +769,20 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
+        <dict>
+            <key>pfm_app_min</key>
+            <string>2.3</string>
+            <key>pfm_default</key>
+            <false/>
+            <key>pfm_description</key>
+            <string>If set to true, Baseline will close the list view window before running FinalScripts. Use this option if you want to utilize FinalScripts to have the user complete actions prior to the Baseline completion dialog.</string>
+            <key>pfm_name</key>
+            <string>CloseListBeforeFinalScripts</string>
+            <key>pfm_title</key>
+            <string>Close List View Before Final Scripts</string>
+            <key>pfm_type</key>
+            <string>boolean</string>
+        </dict>
 		<dict>
 			<key>pfm_description</key>
 			<string>SwiftDialog options for the primary Baseline progress list window.</string>


### PR DESCRIPTION
Improvements in 2.3beta2:
- `CloseListBeforeFinalScripts` option added to determine whether `FinalScripts` happen while the Dialog List view is still open, or after it closes.
    - Defaults to `false`
    - Use this option if you want to encourage a user action or other GUI process to happen between the List View closing and the completion screen showing
    - Final Scripts still do not appear on the List View.