### PR TITLE
Append .pgk to pkgBasename if the URL does not end in .pkg

### DIFF
--- a/Baseline.sh
+++ b/Baseline.sh
@@ -773,6 +773,10 @@ function process_pkgs(){
             # The path to the PKG appears to be a URL.
             #Get the basename of the .pkg we're downloading
             pkgBasename=$(basename "$currentPKGPath")
+	    # Append ".pkg" to $pkgBasename if it does not end in ".pkg" (helpful for Microsoft permalinks)
+            if [[ "$pkgBasename" != *.pkg ]]; then
+                pkgBasename="${pkgBasename}.pkg"
+            fi
             #Set the "currentPKG" variable, this gets used as the download path as well as processed later
             currentPKG="$BaselinePackages"/"$pkgBasename"
             #Check for conflict. If there's already a PKG in the directory we're downloading to, delete it


### PR DESCRIPTION
This allows web URLs that are not direct links to .pkg files to work. It is particularly helpful for Microsoft permalinks.