### PR TITLE
Append .pkg to pkgBasename if the URL does not end in .pkg

### DIFF
--- a/Baseline.sh
+++ b/Baseline.sh
@@ -773,6 +773,10 @@ function process_pkgs(){
             # The path to the PKG appears to be a URL.
             #Get the basename of the .pkg we're downloading
             pkgBasename=$(basename "$currentPKGPath")
+	    # Append ".pkg" to $pkgBasename if it does not end in ".pkg" (helpful for Microsoft permalinks)
+            if [[ "$pkgBasename" != *.pkg ]]; then
+                pkgBasename="${pkgBasename}.pkg"
+            fi
             #Set the "currentPKG" variable, this gets used as the download path as well as processed later
             currentPKG="$BaselinePackages"/"$pkgBasename"
             #Check for conflict. If there's already a PKG in the directory we're downloading to, delete it


### PR DESCRIPTION
Currently, the Packages feature only works for web URLs that are direct links to .pkg files. 

This change allows web URLs that are not direct links to .pkg files to work. This is particularly helpful for Microsoft permalinks. For example, the Microsoft Edge permalink that always forwards to the latest version of Edge: 
> https://go.microsoft.com/fwlink/?linkid=2093504

Without the change, the file is downloaded and saved as `?linkid=2093504`. This causes the `installer` command to fail because it does not recognize the file as a .pkg. Appending .pkg eliminates the issue.

An example Baseline-Output.log has been attached


