### PR TITLE
Append .pkg to pkgBasename if the URL does not end in .pkg

### DIFF
--- a/Baseline.sh
+++ b/Baseline.sh
@@ -775,6 +775,10 @@ function process_pkgs(){
             pkgBasename=$(basename "$currentPKGPath")
             #Set the "currentPKG" variable, this gets used as the download path as well as processed later
             currentPKG="$BaselinePackages"/"$pkgBasename"
+	    # Append .pkg to $pkgBasename if it does not end with .pkg
+            if [[ "$pkgBasename" != *.pkg ]]; then
+                pkgBasename="${pkgBasename}.pkg"
+            fi
             #Check for conflict. If there's already a PKG in the directory we're downloading to, delete it
             rm_if_exists "$currentPKG"
             #Perform the download of the remote pkg


### PR DESCRIPTION
Currently, the Packages feature only works for web URLs that are direct links to .pkg files.

This change allows web URLs that are not direct links to .pkg files to work. This is particularly helpful for Microsoft permalinks. For example, the Microsoft Edge permalink that always forwards to the latest version of Edge: https://go.microsoft.com/fwlink/?linkid=2093504

Without the change, the file is downloaded and saved as `?linkid=2093504`. This causes the `installer` command to fail with error: `package path specified was invalid`. This is because it does not recognize the file as a .pkg. Appending .pkg eliminates the issue.