### PR TITLE
Fix substring matching bug preventing selective dialogue customisation

### DIFF
--- a/Baseline.sh
+++ b/Baseline.sh
@@ -1723,7 +1723,17 @@ fi
 # I grow old … I grow old …I shall wear the bottoms of my trousers rolled..
 function configure_dialog_list_arguments(){
     # $1 is the SwiftDialog option to change, $2 is the default value for that option if its not included in the profile
-    if (($dialogListArguments[(Ie)$1])); then
+    local -a customization_array
+    customization_array=(${(z)dialogListArguments})
+    local found=0
+    local token
+    for token in ${customization_array[@]}; do
+        if [[ "$token" == "$1" || "$token" == "$1="* ]]; then
+            found=1
+            break
+        fi
+    done
+    if (( found )); then
         # $1 was included in the customization, so we report it and move along
         log_message "Dialog List Customization Found: $1"
     else
@@ -1774,7 +1784,17 @@ fi
 
 function configure_dialog_success_arguments(){
     # $1 is the SwiftDialog option to change, $2 is the default value for that option if its not included in the profile
-    if (($dialogSuccessArguments[(Ie)$1])); then
+    local -a customization_array
+    customization_array=(${(z)dialogSuccessArguments})
+    local found=0
+    local token
+    for token in ${customization_array[@]}; do
+        if [[ "$token" == "$1" || "$token" == "$1="* ]]; then
+            found=1
+            break
+        fi
+    done
+    if (( found )); then
         # $1 was included in the customization, so we report it and move along
         log_message "Dialog Success Customization Found: $1"
     else
@@ -1819,7 +1839,17 @@ fi
 
 function configure_dialog_failure_arguments(){
     # $1 is the SwiftDialog option to change, $2 is the default value for that option if its not included in the profile
-    if (($dialogFailureArguments[(Ie)$1])); then
+    local -a customization_array
+    customization_array=(${(z)dialogFailureArguments})
+    local found=0
+    local token
+    for token in ${customization_array[@]}; do
+        if [[ "$token" == "$1" || "$token" == "$1="* ]]; then
+            found=1
+            break
+        fi
+    done
+    if (( found )); then
         # $1 was included in the customization, so we report it and move along
         log_message "Dialog Failure Customization Found: $1"
     else


### PR DESCRIPTION
## Summary

Fixes a bug in the `configure_dialog_*_arguments` functions where substring matching caused false positives when checking for user-provided options.

## Problem

The functions used `(($dialogListArguments[(Ie)$1]))` which performs substring matching on scalar strings. This caused options like `--titlefont` to incorrectly match `--title`, and `--messagefont` to match `--message`, preventing users from customising fonts without losing default text values.

## Solution

Replaced substring matching with proper token-based matching:
- Converts the scalar string to an array using `${(z)}` (zsh word splitting)
- Iterates through tokens with exact string comparison
- Handles both `--option value` and `--option=value` formats

## Changes

Modified three functions in `Baseline.sh`:
- `configure_dialog_list_arguments` (lines 1724-1744)
- `configure_dialog_success_arguments` (lines 1785-1805)
- `configure_dialog_failure_arguments` (lines 1840-1860)

## Testing

Verified fix handles:
- ✅ Rejects false positives (`--titlefont` no longer matches `--title`)
- ✅ Space-separated format: `--title "Custom Title"`
- ✅ Equals-separated format: `--title="Custom Title"`
- ✅ Mixed customisation scenarios
- ✅ No regressions for existing configurations

## Backward Compatibility

Fully backward compatible. Existing configurations will continue to work, and previously broken configurations will now work correctly.