### PR TITLE
skip final dialogs

### DIFF
--- a/Baseline.sh
+++ b/Baseline.sh
@@ -1243,6 +1243,18 @@ function set_progressbar_text(){
 }
 
 function present_failure_window(){
+    # Checking if we are skipping the success window
+    if $pBuddy -c "Print :SkipFailDialog" "$BaselineConfig" > /dev/null 2>&1; then
+        skipFailDialog=$($pBuddy -c "Print :SkipFailDialog" "$BaselineConfig")
+    else
+        skipFailDialog="false"
+    fi
+
+    if [[ "$skipFailDialog" == true ]]; then
+        log_message "Skipping Fail window"
+        return 0
+    fi
+
     #There was at least one failed item. Build fail list
     failListItems=()
     for i in ${failList[@]}; do
@@ -1274,6 +1286,18 @@ function present_failure_window(){
 }
 
 function present_success_window(){
+    # Checking if we are skipping the success window
+    if $pBuddy -c "Print :SkipSuccessDialog" "$BaselineConfig" > /dev/null 2>&1; then
+        skipSuccessDialog=$($pBuddy -c "Print :SkipSuccessDialog" "$BaselineConfig")
+    else
+        skipSuccessDialog="false"
+    fi
+
+    if [[ "$skipSuccessDialog" == true ]]; then
+        log_message "Skipping success window"
+        return 0
+    fi
+
     #Create our Success Dialog Window. We use a "while" loop and a nested if/then in order to bail if there's a configuration file problem.
     #Set a timer for our attempts
     dialogAttemptCount=1

--- a/ProfileManifest/com.secondsonconsulting.baseline.plist
+++ b/ProfileManifest/com.secondsonconsulting.baseline.plist
@@ -910,6 +910,34 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>2.4</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>If set to true, Baseline will not present a Success dialog at completion.</string>
+			<key>pfm_name</key>
+			<string>SkipSuccessDialog</string>
+			<key>pfm_title</key>
+			<string>Skip Success Dialog</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>2.4</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>If set to true, Baseline will not present a Failure dialog at completion.</string>
+			<key>pfm_name</key>
+			<string>SkipFailDialog</string>
+			<key>pfm_title</key>
+			<string>Skip Failure Dialog</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
 			<key>pfm_description</key>
 			<string>SwiftDialog options for the primary Baseline progress list window.</string>
 			<key>pfm_name</key>

--- a/ReleaseNotes_2.4beta1.md
+++ b/ReleaseNotes_2.4beta1.md
@@ -31,6 +31,9 @@ The #baseline channel on the [Mac Admins Slack](https://macadmins.org) is the be
         - `StatusIconFail`
     - Any item without one of these keys will use the default for that status.
     - This feature requires SwiftDialog 3.0, which is pending official release.
+- Added the ability to skip the final Success or Fail windows entirely
+    - `SkipSuccessDialog` is a new top level `boolean` key that defaults to false
+    - `SkipFailDialog` is a new top level `boolean` key that defaults to false
 
 ## Improvements
 - Cleaned up code for sending status updates


### PR DESCRIPTION
- Added the ability to skip the final Success or Fail windows entirely
    - `SkipSuccessDialog` is a new top level `boolean` key that defaults to false
    - `SkipFailDialog` is a new top level `boolean` key that defaults to false