### PR TITLE
Fixing wait_for_user function

### DIFF
--- a/Baseline.sh
+++ b/Baseline.sh
@@ -433,7 +433,7 @@ function wait_for_user(){
         sleep 1
         else
             #Logged in user found, but continue the loop until Dock and Finder processes are running
-            if pgrep -q "dock" && pgrep -q "Finder"; then
+            if pgrep -xq "Dock" && pgrep -xq "Finder"; then
                 uid=$(id -u "$currentUser")
                 log_message "Verified User is logged in: $currentUser UID: $uid"
                 verifiedUser="true"


### PR DESCRIPTION
This addresses Issue #115 edge case where the `dock` launch agent isn't running but the `Dock` process is. We now look for specific dock processes by name, case sensitive, to ensure no false positives or negatives on the Finder and Dock process.