### PR TITLE
Added support for PreflightScripts and per-item BailOut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Build/.DS_Store
 TestConfig.plist
 testConfig.mobileconfig
 dialog.pkg
+/.local

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -741,9 +741,22 @@ function build_dialog_array(){
     done
 }
 
+function bail_on_item_failure(){
+# Called when an item has BailOnFailure set to true and has failed after max retries.
+# failList, dialog_status, and update_tracker must all be called before this function.
+# present_failure_window is a no-op at the PreflightScripts stage (finalFailureCommand
+# not yet built), so bail exits cleanly but without a Dialog window at that stage.
+    report_message "BailOnFailure triggered by: ${1}"
+    present_failure_window
+    cleanup_and_restart 99 "BailOnFailure: exiting after failure of: ${1}"
+}
+
 function process_scripts(){
 # Usage: process_scripts ProfileKey
 # Actual use: process_scripts [ PreflightScripts | InitialScripts | Scripts | FinalScripts ]
+# NOTE: PreflightScripts run before SwiftDialog and Installomator are installed, and before
+# any user is logged in. Dialog status calls are safe (they write to the command file that
+# nobody is reading yet) but AsUser:true will always fail at this stage.
     #Set an index internal to this function
     currentIndex=0
     #Loop through and test if there is a value in the slot of this index for the given array
@@ -763,6 +776,7 @@ function process_scripts(){
         local currentScriptPath
         local currentDisplayName
         local scriptDownloadExitCode
+        local bailOnFailure
         #Get the display name of the label we're installing. We need this to update the dialog list
         currentDisplayName=$($pBuddy -c "Print :${1}:${currentIndex}:DisplayName" "$BaselineConfig")
         #Set the current script name
@@ -946,12 +960,18 @@ function process_scripts(){
             report_message "Failed Item - Script runtime error: $currentScript after $currentAttemptCount attempts - Exit Code: $scriptExitCode"
             dialog_status "$currentDisplayName" "${currentStatusIconFail}"
             failList+=("$currentDisplayName")
+            update_tracker $currentDisplayName $scriptExitCode
+            # Check if this item is configured to bail Baseline on failure
+            bailOnFailure=$($pBuddy -c "Print :${1}:${currentIndex}:BailOnFailure" "$BaselineConfig" 2> /dev/null)
+            if [[ "$bailOnFailure" == "true" ]]; then
+                bail_on_item_failure "$currentDisplayName"
+            fi
         else
             report_message "Successful Item - Script: $currentScript"
             dialog_status "$currentDisplayName" "${currentStatusIconSuccess}"
             successList+=("$currentDisplayName")
+            update_tracker $currentDisplayName $scriptExitCode
         fi
-        update_tracker $currentDisplayName $scriptExitCode
 
        #Iterate index for next loop
         currentIndex=$((currentIndex+1))
@@ -1923,6 +1943,29 @@ check_silent_option
 initiate_tracker_file
 check_exit_condition
 
+################################
+#   Run Preflight Scripts       #
+################################
+# PreflightScripts run before SwiftDialog and Installomator are installed, before wait_for_user,
+# and before the Dialog list window is built. They are not shown in the Dialog list view.
+#
+# These support the same keys as InitialScripts: ScriptPath, Arguments, SHA256, MD5, Retries, CurlOptions.
+# AsUser is parsed but will always produce a failure; do not use it in PreflightScripts.
+
+# set_default_retry_values and check_bail_out_configuration are called here
+# (they are also called again before InitialScripts after any config-swap)
+# Initialize fail/success lists before PreflightScripts so that failures at this stage
+# are preserved through the array initialization block that runs later (post-user-login).
+failList=()
+successList=()
+
+set_default_retry_values
+check_bail_out_configuration
+process_scripts PreflightScripts
+
+#Check if a custom plist was delivered during PreflightScripts
+check_for_custom_plist
+
 #############################################
 #   Configure Default Installomator Options #
 #############################################
@@ -1980,9 +2023,6 @@ userHomeFolder=$(dscl . -read /users/${currentUser} NFSHomeDirectory | cut -d " 
 dialogList=()
 dialogListItems=()
 dialogListJson=()
-failList=()
-successList=()
-
 installomatorLabels=()
 installomatorOptions=()
 

--- a/Baseline.sh
+++ b/Baseline.sh
@@ -743,26 +743,26 @@ function build_dialog_array(){
 
 function process_scripts(){
 # Usage: process_scripts ProfileKey
-# Actual use: process_scripts [ InitialScripts | Scripts ]
+# Actual use: process_scripts [ PreflightScripts | InitialScripts | Scripts | FinalScripts ]
     #Set an index internal to this function
     currentIndex=0
     #Loop through and test if there is a value in the slot of this index for the given array
     #If this command fails it means we've reached the end of the array in the config file (or there are none) and we exit our loop
     while $pBuddy -c "Print :${1}:${currentIndex}" "$BaselineConfig" > /dev/null 2>&1; do
         check_for_bail_out
-        #Unset variables for next loop
-        unset useVerboseJamf
-        unset jamfVerbosePID
-        unset expectedMD5
-        unset actualMD5
-        unset expectedSHA256
-        unset actualSHA256
-        unset currentArguments
-        unset currentArgumentArray
-        unset currentScript
-        unset currentScriptPath
-        unset currentDisplayName
-        unset scriptDownloadExitCode
+        # Local vars
+        local useVerboseJamf
+        local jamfVerbosePID
+        local expectedMD5
+        local actualMD5
+        local expectedSHA256
+        local actualSHA256
+        local currentArguments
+        local currentArgumentArray
+        local currentScript
+        local currentScriptPath
+        local currentDisplayName
+        local scriptDownloadExitCode
         #Get the display name of the label we're installing. We need this to update the dialog list
         currentDisplayName=$($pBuddy -c "Print :${1}:${currentIndex}:DisplayName" "$BaselineConfig")
         #Set the current script name
@@ -959,7 +959,7 @@ function process_scripts(){
         # This gets set for use with the BailOut feature
         previousDisplayName="$currentDisplayName"
 
-        #Stuff in this section only happens if we're processing Scripts and not InitialScripts
+        #Stuff in this section only happens if we're processing "Scripts" and not any other Script Type
         if [ "$1" = "Scripts" ]; then
             increment_progress_bar
             #If we're using jamf, and jamf verbose is configured
@@ -983,20 +983,20 @@ function process_pkgs(){
     #If this command fails it means we've reached the end of the array in the config file (or there are none) and we exit our loop
     while $pBuddy -c "Print :Packages:${currentIndex}" "$BaselineConfig" > /dev/null 2>&1; do
         check_for_bail_out
-        # Unset variables for next loop
-        unset currentPKG
-        unset currentPKGPath
-        unset expectedTeamID
-        unset expectedMD5
-        unset actualMD5
-        unset expectedSHA256
-        unset actualSHA256
-        unset actualTeamID
-        unset currentArguments
-        unset currentArgumentArray
-        unset currentDisplayName
-        unset pkgBasename
-        unset downloadResult
+        # Local vars
+        local currentPKG
+        local currentPKGPath
+        local expectedTeamID
+        local expectedMD5
+        local actualMD5
+        local expectedSHA256
+        local actualSHA256
+        local actualTeamID
+        local currentArguments
+        local currentArgumentArray
+        local currentDisplayName
+        local pkgBasename
+        local downloadResult
 
         #Get the display name of the label we're installing. We need this to update the dialog list
         currentDisplayName=$($pBuddy -c "Print :Packages:${currentIndex}:DisplayName" "$BaselineConfig")

--- a/ProfileManifest/com.secondsonconsulting.baseline.plist
+++ b/ProfileManifest/com.secondsonconsulting.baseline.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2025-11-02T00:00:00Z</date>
+	<date>2026-05-14T00:00:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -183,6 +183,7 @@ A profile can consist of payloads with different version numbers. For example, c
 				</array>
 				<key>General</key>
 				<array>
+					<string>PreflightScripts</string>
 					<string>InitialScripts</string>
 					<string>Installomator</string>
 					<string>Packages</string>
@@ -193,6 +194,114 @@ A profile can consist of payloads with different version numbers. For example, c
 			</dict>
 			<key>pfm_type</key>
 			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>3.1</string>
+			<key>pfm_description</key>
+			<string>Define scripts that run immediately after the configuration file is verified, before SwiftDialog and Installomator are installed and before any user is logged in. Use for environment checks, installing custom/specific SwiftDialog or Installomator, pre-conditions, or config-swap logic that must complete before any other Baseline activity. Scripts always run as root; AsUser is not supported at this stage.</string>
+			<key>pfm_name</key>
+			<string>PreflightScripts</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_description</key>
+							<string>The name used in logs for this Preflight Script. PreflightScripts do not appear in the SwiftDialog list view.</string>
+							<key>pfm_name</key>
+							<string>DisplayName</string>
+							<key>pfm_title</key>
+							<string>Display Name</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>A path to the script you want to run. Can be a local file path or a URL.</string>
+							<key>pfm_name</key>
+							<string>ScriptPath</string>
+							<key>pfm_title</key>
+							<string>Script Path</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>The expected SHA256 of the script being run.</string>
+							<key>pfm_name</key>
+							<string>SHA256</string>
+							<key>pfm_title</key>
+							<string>SHA256</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>The expected MD5 of the script being run.</string>
+							<key>pfm_name</key>
+							<string>MD5</string>
+							<key>pfm_title</key>
+							<string>MD5</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>Arguments you want to pass to the script when it is run.</string>
+							<key>pfm_name</key>
+							<string>Arguments</string>
+							<key>pfm_title</key>
+							<string>Arguments</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<false/>
+							<key>pfm_description</key>
+							<string>The number of times Baseline will retry this specific item if it fails. If omitted, will use the Global Retries Default.</string>
+							<key>pfm_name</key>
+							<string>Retries</string>
+							<key>pfm_title</key>
+							<string>Retries</string>
+							<key>pfm_type</key>
+							<string>integer</string>
+						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<false/>
+							<key>pfm_description</key>
+							<string>Custom Curl Options to use when downloading this script.</string>
+							<key>pfm_name</key>
+							<string>CurlOptions</string>
+							<key>pfm_title</key>
+							<string>Curl Options</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<false/>
+							<key>pfm_description</key>
+							<string>If set to true, Baseline will stop processing and exit with a failure if this script fails after all retries. The failure dialog will be shown if possible. Default is false.</string>
+							<key>pfm_name</key>
+							<string>BailOnFailure</string>
+							<key>pfm_title</key>
+							<string>Bail on Failure</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
+						</dict>
+					</array>
+					<key>pfm_type</key>
+					<string>dictionary</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>PreflightScripts</string>
+			<key>pfm_type</key>
+			<string>array</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
@@ -287,6 +396,18 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>Curl Options</string>
 							<key>pfm_type</key>
 							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<false/>
+							<key>pfm_description</key>
+							<string>If set to true, Baseline will stop processing and exit with a failure if this script fails after all retries. The failure dialog will be shown if possible. Default is false.</string>
+							<key>pfm_name</key>
+							<string>BailOnFailure</string>
+							<key>pfm_title</key>
+							<string>Bail on Failure</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
 						</dict>
 					</array>
 					<key>pfm_type</key>
@@ -762,6 +883,18 @@ A profile can consist of payloads with different version numbers. For example, c
 							<key>pfm_type</key>
 							<string>string</string>
 						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<false/>
+							<key>pfm_description</key>
+							<string>If set to true, Baseline will stop processing and exit with a failure if this script fails after all retries. The failure dialog will be shown if possible. Default is false.</string>
+							<key>pfm_name</key>
+							<string>BailOnFailure</string>
+							<key>pfm_title</key>
+							<string>Bail on Failure</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
+						</dict>
 					</array>
 					<key>pfm_type</key>
 					<string>dictionary</string>
@@ -929,6 +1062,18 @@ A profile can consist of payloads with different version numbers. For example, c
 							<string>Curl Options</string>
 							<key>pfm_type</key>
 							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<false/>
+							<key>pfm_description</key>
+							<string>If set to true, Baseline will stop processing and exit with a failure if this script fails after all retries. The failure dialog will be shown if possible. Default is false.</string>
+							<key>pfm_name</key>
+							<string>BailOnFailure</string>
+							<key>pfm_title</key>
+							<string>Bail on Failure</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
 						</dict>
 					</array>
 					<key>pfm_type</key>
@@ -1308,6 +1453,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>5</integer>
+	<integer>7</integer>
 </dict>
 </plist>


### PR DESCRIPTION
- PreflightScripts run immediately after a configuration file is validated
     - This means they run prior to swiftDialog or Installomator being installed. This is a good place to install custom versions of these tools or other management/orchestration tools like munki
- Per Item Bailout is now possible for all script types. If a script with `BailOnFailure` boolean set to true fails (after all retries) then Baseline will stop processing any additional items.

Plan is to extend both of these features to `Packages` and introduce `PreflightPackages` key as well, stay tuned.